### PR TITLE
Bugfix: Magic Quotes

### DIFF
--- a/src/Http/Factories/RequestFactory.php
+++ b/src/Http/Factories/RequestFactory.php
@@ -6,6 +6,7 @@
 
 namespace NewsHour\WPCoreThemeComponents\Http\Factories;
 
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -45,9 +46,28 @@ final class RequestFactory
     public static function getStack(): RequestStack
     {
         if (self::$stack == null) {
-            $request = Request::createFromGlobals();
+
+            // Fixes for Wordpress's auto-escaping mutations.
+            $request = new Request(
+                stripslashes_deep($_GET),
+                stripslashes_deep($_POST),
+                [],
+                stripslashes_deep($_COOKIE),
+                $_FILES,
+                stripslashes_deep($_SERVER)
+            );
+
+            // Borrowed from Request's `createFromGlobals` method.
+            if (str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
+                && \in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'DELETE', 'PATCH'])
+            ) {
+                parse_str($request->getContent(), $data);
+                $request->request = new InputBag($data);
+            }
+
             $request->setLocale(get_locale());
             $request->setDefaultLocale(get_locale());
+
             $stack = new RequestStack();
             $stack->push($request);
             self::$stack = $stack;

--- a/src/Http/Factories/RequestFactory.php
+++ b/src/Http/Factories/RequestFactory.php
@@ -46,19 +46,24 @@ final class RequestFactory
     public static function getStack(): RequestStack
     {
         if (self::$stack == null) {
-
             // Fixes for Wordpress's auto-escaping mutations.
+            $_get = stripslashes_deep($_GET);
+            $_post = stripslashes_deep($_POST);
+            $_cookie = stripslashes_deep($_COOKIE);
+            $_server = stripslashes_deep($_SERVER);
+
             $request = new Request(
-                stripslashes_deep($_GET),
-                stripslashes_deep($_POST),
+                is_array($_get) ? $_get : [],
+                is_array($_post) ? $_post : [],
                 [],
-                stripslashes_deep($_COOKIE),
+                is_array($_cookie) ? $_cookie : [],
                 $_FILES,
-                stripslashes_deep($_SERVER)
+                is_array($_server) ? $_server : []
             );
 
             // Borrowed from Request's `createFromGlobals` method.
-            if (str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
+            if (
+                str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
                 && \in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'DELETE', 'PATCH'])
             ) {
                 parse_str($request->getContent(), $data);

--- a/src/Tests/mock_wp_functions.php
+++ b/src/Tests/mock_wp_functions.php
@@ -143,6 +143,18 @@ function is_user_logged_in()
 }
 
 /**
+ * @return mixed
+ */
+function stripslashes_deep($value)
+{
+    if (is_string($value)) {
+        return stripslashes($value);
+    }
+
+    return $value;
+}
+
+/**
  * @return string
  */
 function wp_timezone()


### PR DESCRIPTION
This PR accounts for Wordpress's application of "magic quotes" on incoming request data before initializing a Request object.