### PR TITLE
Return object or null.

### DIFF
--- a/src/Query/ResultSet.php
+++ b/src/Query/ResultSet.php
@@ -46,9 +46,9 @@ interface ResultSet
      * Retrieve the first result by primary key.
      *
      * @param int $pk
-     * @return array
+     * @return object|null
      */
-    public function pk($pk): array;
+    public function pk($pk): ?object;
 
     /**
      * Filter a query by keyword args. See WP_Query documentation for a full


### PR DESCRIPTION
This PR updates a ResultSet to return an object (or null) when call pk(). Currently it returns an array, however, this is duplicate functionality to calling id() with a single id/pk. Returning an object provides more convenience by eliminating array access. The method also throws an exception for when multiple records for a pk exist making error handling also more convenient.