### PR TITLE
Bugfix: Removing set limit.

### DIFF
--- a/src/Query/PostsResultSet.php
+++ b/src/Query/PostsResultSet.php
@@ -353,7 +353,6 @@ final class PostsResultSet implements ResultSet
 
         $key = $parent ? 'post_parent__not_in' : 'post__not_in';
         $this->queryParams[$key] = $clean;
-        $this->limit(-1);
 
         return $this;
     }


### PR DESCRIPTION
This PR removes a set limit value in the `exclude` method. We shouldn't be setting the limit here.