### PR TITLE
Additional options for LoginRequired annotation.

### DIFF
--- a/src/Annotations/LoginRequired.php
+++ b/src/Annotations/LoginRequired.php
@@ -9,6 +9,7 @@ namespace NewsHour\WPCoreThemeComponents\Annotations;
 /**
  * Provides an annotation for controller methods to check for logged in users. If a capability is
  * passed to the constructor, the annotation will also check if the user has the capability.
+ * Status codes (`$statusCode`) and redirect locations (`$next`) may also be passed as well.
  *
  * @Annotation
  * @NamedArgumentConstructor
@@ -16,21 +17,47 @@ namespace NewsHour\WPCoreThemeComponents\Annotations;
 final class LoginRequired
 {
     private string $capability = '';
+    private string $next = '';
+    private int $statusCode = 403;
 
     /**
      * @param string $capability
+     * @param integer $statusCode
+     * @param string $next
      */
-    public function __construct($capability = '')
+    public function __construct($capability = '', $statusCode = 403, $next = '')
     {
         $this->capability = (string) $capability;
+        $this->next = (string) $next;
+        $this->statusCode = (int) $statusCode;
     }
 
     /**
+     * Returns the WP capability string.
+     *
      * @return string
      */
     public function getCapability(): string
     {
         return $this->capability;
+    }
+
+    /**
+     * Returns a redirect location.
+     *
+     * @return string
+     */
+    public function getNext(): string
+    {
+        return $this->next;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
     }
 
     /**

--- a/src/KernelUtilities.php
+++ b/src/KernelUtilities.php
@@ -47,8 +47,17 @@ final class KernelUtilities
     {
         $this->kernel->shutdown();
 
+        if ($statusCode == 404 && function_exists('get_query_template')) {
+            status_header(404);
+            nocache_headers();
+
+            if (!empty($template = get_query_template('404'))) {
+                include $template;
+                exit;
+            }
+        }
+
         if (function_exists('wp_die')) {
-            $this->kernel->shutdown();
             remove_all_filters('status_header'); // Clear this filter chain so nothing overrides the status code.
             wp_die($message, $title, ['response' => $statusCode]);
         }


### PR DESCRIPTION
This PR adds two new options for the `LoginRequired` annotation: `$next` and `$statusCode`. `$next` allows for a redirection URL to be set for failed validation and `$statusCode` allows for the default 403 status code to be overridden. 